### PR TITLE
change badge style

### DIFF
--- a/lib/IconToggle.js
+++ b/lib/IconToggle.js
@@ -133,7 +133,7 @@ export default class IconToggle extends Component {
                         >
                             <View style={{ flex: 1, justifyContent: 'center' }}>
                                 <Text style={[styles.badgeText, { color: getColor(badge.textColor) }, badge.value > 99 ? { fontSize: 8 } : { fontSize: 10 }]}>
-                                    {badge.value}
+                                    {badge.value > 99 ? '99+' : badge.value}
                                 </Text>
                             </View>
                         </Animated.View>


### PR DESCRIPTION
if the badge value large than 99, display '99+' instead of the real number
